### PR TITLE
Use native Float16

### DIFF
--- a/src/blas.jl
+++ b/src/blas.jl
@@ -62,8 +62,8 @@ function gemmEx!(transA::Char, transB::Char, alpha::Number, A, B, beta::Number, 
                                 )
 
     GemmKernels.matmul(convert_matrix(A), convert_matrix(B), convert_matrix(C), convert_matrix(C), conf;
-                       transform_shared_to_regs_c = Transform.Elementwise(x -> x * (beta / alpha)),
-                       transform_regs_to_shared_d = Transform.Elementwise(x -> x * alpha),
+                       transform_shared_to_regs_a = Transform.Elementwise(x -> x * alpha),
+                       transform_shared_to_regs_c = Transform.Elementwise(x -> x * beta),
                        kernel = kernel(a_layout, b_layout)
                       )
 end


### PR DESCRIPTION
@thomasfaingnaert:

> I had to use some ugly workarounds to get around the fact that Float16 was mapped to i16 instead of half, but that shouldn't be a problem in Julia 1.6, so that code can be cleaned up significantly.

Which other workaround are there?