### PR TITLE
Fix layout fragment type mismatch

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -69,7 +69,7 @@ struct AlignedColMajor{T} <: LayoutBase{T} end
 
 @inline physical_size(::Type{Padded{AlignedColMajor{T}, P}}, logical_size::NamedTuple) where {T, P} = (logical_size[1] + P, logical_size[2])
 
-@inline fragtype(::Type{AlignedColMajor{T}}, tile_size::NamedTuple) where {T} = NTuple{8, VecElement{Float16}}
+@inline fragtype(::Type{AlignedColMajor{T}}, tile_size::NamedTuple) where {T} = NTuple{16 ÷ sizeof(T), VecElement{T}}
 
 @inline function load(::Type{AlignedColMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     N = 16 ÷ sizeof(T)
@@ -114,7 +114,7 @@ struct AlignedRowMajor{T} <: LayoutBase{T} end
 
 @inline physical_size(::Type{Padded{AlignedRowMajor{T}, P}}, logical_size::NamedTuple) where {T, P} = (logical_size[2] + P, logical_size[1])
 
-@inline fragtype(::Type{AlignedRowMajor{T}}, tile_size::NamedTuple) where {T} = NTuple{8, VecElement{Float16}}
+@inline fragtype(::Type{AlignedRowMajor{T}}, tile_size::NamedTuple) where {T} = NTuple{16 ÷ sizeof(T), VecElement{T}}
 
 @inline function load(::Type{AlignedRowMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     N = 16 ÷ sizeof(T)


### PR DESCRIPTION
This fixes an issue causing a type mismatch in the `matmul_pipelined` kernel between
the return type of Layout.load (inferred by the compiler) and the element type of the `{a,b}_fragment` arrays (hinted by the fragtype function) that came up when working with non-Float16 input matrices.

place of mismatch:
https://github.com/JuliaGPU/GemmKernels.jl/blob/322d4ca21f5969a4c408570c2ad660d26895add8/src/kernel.jl#L201