### PR TITLE
Add quick benchmark runner.

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,2 +1,4 @@
 *.csv
 *.pdf
+*.json
+Manifest.toml

--- a/benchmarks/Project.toml
+++ b/benchmarks/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"

--- a/benchmarks/benchmark.jl
+++ b/benchmarks/benchmark.jl
@@ -1,0 +1,71 @@
+using BenchmarkTools
+using GemmKernels, CUDA
+using CUDA: unsafe_free!
+
+using StableRNGs
+rng = StableRNG(123)
+
+@info "Loading benchmarks"
+SUITE = BenchmarkGroup()
+
+let group = addgroup!(SUITE, "wmma")
+    for N in [128, 16384], a_layout in ['N', 'T'], b_layout in ['N', 'T']
+        M = N
+        K = N
+
+        a_h = rand(Float16, (M, K)) / sqrt(Float16(K))
+        b_h = rand(Float16, (K, N)) / sqrt(Float16(K))
+        c_h = rand(Float32, (M, N))
+
+        # Transpose input if necessary
+        a_h = a_layout == 'T' ? transpose(a_h) : a_h
+        b_h = b_layout == 'T' ? transpose(b_h) : b_h
+
+        alpha = rand(Float32)
+        beta = rand(Float32)
+
+        a = CuArray(a_h)
+        b = CuArray(b_h)
+        c = CuArray(c_h)
+
+        group["Float16*Float16=Float32 (N=$N, A=$a_layout, B=$b_layout)"] =
+            @benchmarkable(
+                CUDA.@sync(GemmKernels.BLAS.gemmEx!($a_layout, $b_layout, $alpha, a, b, $beta, c)),
+                setup=(a=CuArray($a_h); b=CuArray($b_h); c=CuArray($c_h)),
+                teardown=(unsafe_free!(a); unsafe_free!(b); unsafe_free!(c))
+            )
+    end
+end
+
+@info "Warming-up benchmarks"
+warmup(SUITE; verbose=false)
+
+paramsfile = joinpath(@__DIR__, "params.json")
+if !isfile(paramsfile)
+    @info "Tuning benchmarks"
+    tune!(SUITE)
+    BenchmarkTools.save(paramsfile, params(SUITE))
+else
+    loadparams!(SUITE, BenchmarkTools.load(paramsfile)[1], :evals, :samples)
+end
+
+@info "Running benchmarks"
+results = run(SUITE; verbose=true)
+println(results)
+
+# write out the results
+BenchmarkTools.save(joinpath(@__DIR__, "results.json"), results)
+
+# compare against previous results
+# TODO: store these results so that we can compare when benchmarking PRs
+reference_path = joinpath(@__DIR__, "reference.json")
+if ispath(reference_path)
+    reference = BenchmarkTools.load(reference_path)[1]
+    comparison = judge(minimum(results), minimum(reference))
+
+    println("Improvements:")
+    println(improvements(comparison))
+
+    println("Regressions:")
+    println(regressions(comparison))
+end


### PR DESCRIPTION
Easier to run: just `julia benchmarks.jl`, and save the `results.json` to a `reference.json` to enable comparisons. Example output:

```
$ cd benchmark && jl --project benchmark.jl
[ Info: Loading benchmarks
[ Info: Warming-up benchmarks
[ Info: Running benchmarks
(1/1) benchmarking "wmma"...
  (1/8) benchmarking "Float16*Float16=Float32 (N=16384, A=T, B=T)"...
  done (took 7.194764988 seconds)
  (2/8) benchmarking "Float16*Float16=Float32 (N=128, A=T, B=T)"...
  done (took 1.772746151 seconds)
  (3/8) benchmarking "Float16*Float16=Float32 (N=128, A=N, B=N)"...
  done (took 1.489494904 seconds)
  (4/8) benchmarking "Float16*Float16=Float32 (N=128, A=T, B=N)"...
  done (took 1.662320659 seconds)
  (5/8) benchmarking "Float16*Float16=Float32 (N=16384, A=N, B=T)"...
  done (took 5.56066775 seconds)
  (6/8) benchmarking "Float16*Float16=Float32 (N=128, A=N, B=T)"...
  done (took 1.578134163 seconds)
  (7/8) benchmarking "Float16*Float16=Float32 (N=16384, A=N, B=N)"...
  done (took 5.31994601 seconds)
  (8/8) benchmarking "Float16*Float16=Float32 (N=16384, A=T, B=N)"...
  done (took 7.849658099 seconds)
done (took 32.795208209 seconds)
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "wmma" => 8-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "Float16*Float16=Float32 (N=16384, A=T, B=N)" => Trial(832.501 ms)
          "Float16*Float16=Float32 (N=128, A=T, B=T)" => Trial(72.149 μs)
          "Float16*Float16=Float32 (N=128, A=N, B=N)" => Trial(76.000 μs)
          "Float16*Float16=Float32 (N=128, A=T, B=N)" => Trial(76.839 μs)
          "Float16*Float16=Float32 (N=16384, A=T, B=T)" => Trial(883.415 ms)
          "Float16*Float16=Float32 (N=16384, A=N, B=T)" => Trial(796.416 ms)
          "Float16*Float16=Float32 (N=128, A=N, B=T)" => Trial(70.820 μs)
          "Float16*Float16=Float32 (N=16384, A=N, B=N)" => Trial(812.910 ms)
Improvements:
0-element BenchmarkTools.BenchmarkGroup:
  tags: []
Regressions:
1-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "wmma" => 4-element BenchmarkTools.BenchmarkGroup:
          tags: []
          "Float16*Float16=Float32 (N=16384, A=T, B=N)" => TrialJudgement(+31.21% => regression)
          "Float16*Float16=Float32 (N=16384, A=T, B=T)" => TrialJudgement(+44.24% => regression)
          "Float16*Float16=Float32 (N=16384, A=N, B=N)" => TrialJudgement(+41.30% => regression)
          "Float16*Float16=Float32 (N=16384, A=N, B=T)" => TrialJudgement(+36.49% => regression)
```

The regressions here are due to https://github.com/JuliaGPU/GemmKernels.jl/pull/83 -- should have done this the other way around.

An easier way is probably to report the number of registers, but it isn't easy to get a hold of the compiled kernel. Maybe a verbosity env var?