### PR TITLE
update CUDA compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-CUDA = "2, 3"
+CUDA = "3.5"
 ForwardDiff = "0.10"
 GPUifyLoops = "0.2"
 LLVM = "3, 4"


### PR DESCRIPTION
In a recent commit (merge #82), dynamic allocation of shared memory was changed from the deprecated `@cuDynamicSharedMem` macro to the replacing `CuDynamicSharedArray` function,
this breaks compatability with CUDA.jl versions before v3.5.0 as the `CuDynamicSharedArray` function was only added in CUDA.jl v3.5.