### PR TITLE
Replace KernelAbstractions with LLVMLoopInfo.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,13 @@ version = "0.1.0"
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
+LLVMLoopInfo = "8b046642-f1f6-4319-8d3c-209ddc03c586"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 CUDA = "3.5, 4"
 ForwardDiff = "0.10"
-KernelAbstractions = "0.7, 0.8, 0.9"
 LLVM = "3, 4, 5, 6"
+LLVMLoopInfo = "1"
 julia = "1.6"

--- a/src/epilogue.jl
+++ b/src/epilogue.jl
@@ -4,7 +4,7 @@ module Epilogue
 using CUDA
 using GemmKernels
 using GemmKernels.Tiling
-using KernelAbstractions.Extras: @unroll
+using LLVMLoopInfo: @loopinfo
 
 # ----------------
 # Default epilogue
@@ -24,8 +24,8 @@ struct Default end
     block_tile = Tile(conf.block_shape)
 
     # Cooperatively store a block_shape.M x block_shape.N tile of D from shared to global memory within one threadblock
-    @unroll for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
-        @unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
+    @loopinfo unrollfull for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
+        @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
             x = Layout.load(conf.shared_d_layout, shmem_d, thread_tile)
             x = transform(x, thread_tile)
             Layout.store!(conf.global_d_layout, d, x, translate_base(thread_tile, (M = block_i, N = block_j)))
@@ -63,8 +63,8 @@ end
     block_tile = Tile(conf.block_shape)
 
     # Cooperatively store a block_shape.M x block_shape.N tile of D from shared to global memory within one threadblock
-    @unroll for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
-        @unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
+    @loopinfo unrollfull for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
+        @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
             x = Layout.load(conf.shared_d_layout, shmem_d, thread_tile)
             x = apply_bias(x, ep.bias_pointer, translate_base(thread_tile, (M = block_i, N = block_j)))
             x = transform(x, thread_tile)

--- a/src/epilogue.jl
+++ b/src/epilogue.jl
@@ -24,8 +24,8 @@ struct Default end
     block_tile = Tile(conf.block_shape)
 
     # Cooperatively store a block_shape.M x block_shape.N tile of D from shared to global memory within one threadblock
-    @loopinfo unrollfull for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
-        @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
+    @loopinfo unroll for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
+        @loopinfo unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
             x = Layout.load(conf.shared_d_layout, shmem_d, thread_tile)
             x = transform(x, thread_tile)
             Layout.store!(conf.global_d_layout, d, x, translate_base(thread_tile, (M = block_i, N = block_j)))
@@ -63,8 +63,8 @@ end
     block_tile = Tile(conf.block_shape)
 
     # Cooperatively store a block_shape.M x block_shape.N tile of D from shared to global memory within one threadblock
-    @loopinfo unrollfull for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
-        @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
+    @loopinfo unroll for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
+        @loopinfo unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
             x = Layout.load(conf.shared_d_layout, shmem_d, thread_tile)
             x = apply_bias(x, ep.bias_pointer, translate_base(thread_tile, (M = block_i, N = block_j)))
             x = transform(x, thread_tile)

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -30,8 +30,8 @@ function matmul_singlestage(a, b, c, d,
     # (1) Cooperatively load a block_shape.M x block_shape.N tile of C from global to shared memory within one threadblock
     shmem_c = CuDynamicSharedArray(Layout.eltype(conf.shared_c_layout), Layout.physical_size(conf.shared_c_layout, block_tile.MN.size))
 
-    @loopinfo unrollfull for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
-        @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
+    @loopinfo unroll for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
+        @loopinfo unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
             x = Layout.load(conf.global_c_layout, c, translate_base(thread_tile, (M = block_i, N = block_j)))
             x = transf_gl2sh_c(x, thread_tile)
             Layout.store!(conf.shared_c_layout, shmem_c, x, thread_tile)
@@ -45,8 +45,8 @@ function matmul_singlestage(a, b, c, d,
 
     c_frags = LocalArray{Tuple{num_fragments_m, num_fragments_n}, Operator.fragtype_accum(conf.operator, conf.shared_c_layout)}(undef)
 
-    @loopinfo unrollfull for i = 1 : num_fragments_m
-        @loopinfo unrollfull for j = 1 : num_fragments_n
+    @loopinfo unroll for i = 1 : num_fragments_m
+        @loopinfo unroll for j = 1 : num_fragments_n
             tile = translate_offset(warp_tile, (M = (i-1)*conf.compute_op_shape.M, N = (j-1)*conf.compute_op_shape.N))
             @inbounds c_frags = setindex(c_frags, transf_sh2rf_c(Operator.load_c(conf.operator, conf.shared_c_layout, shmem_c, tile), tile), i ,j)
         end
@@ -59,11 +59,11 @@ function matmul_singlestage(a, b, c, d,
     shmem_b = CuDynamicSharedArray(Layout.eltype(conf.shared_b_layout), Layout.physical_size(conf.shared_b_layout, block_tile.KN.size),
                                   length(shmem_a) * sizeof(Layout.eltype(conf.shared_a_layout)))
 
-    @loopinfo unrollfull for block_k = 0 : block_tile.size.K : gemm_sz.size.K - 1
+    @loopinfo unroll for block_k = 0 : block_tile.size.K : gemm_sz.size.K - 1
         if Layout.threadblock_condition(conf.global_a_layout, conf.global_b_layout, block_i, block_j, block_k, block_tile)
             # (3.1) Cooperatively load a block_shape.M x block_shape.K tile of A from global to shared memory within one threadblock
-            @loopinfo unrollfull for warp_tile = parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major)
-                @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major)
+            @loopinfo unroll for warp_tile = parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major)
+                @loopinfo unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major)
                     x = Layout.load(conf.global_a_layout, a, translate_base(thread_tile, (M = block_i, K = block_k)))
                     x = transf_gl2sh_a(x, thread_tile)
                     Layout.store!(conf.shared_a_layout, shmem_a, x, thread_tile)
@@ -71,8 +71,8 @@ function matmul_singlestage(a, b, c, d,
             end
 
             # (3.2) Cooperatively load a block_shape.K x block_shape.N tile of B from global to shared memory within one threadblock
-            @loopinfo unrollfull for warp_tile = parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major)
-                @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major)
+            @loopinfo unroll for warp_tile = parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major)
+                @loopinfo unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major)
                     x = Layout.load(conf.global_b_layout, b, translate_base(thread_tile, (K = block_k, N = block_j)))
                     x = transf_gl2sh_b(x, thread_tile)
                     Layout.store!(conf.shared_b_layout, shmem_b, x, thread_tile)
@@ -82,11 +82,11 @@ function matmul_singlestage(a, b, c, d,
             sync_threads()
 
             # (3.3) Calculate a compute_warp.M x compute_warp.N tile of D, using a compute_warp.M x compute_warp.N x compute_warp.K operation
-            @loopinfo unrollfull for warp_tile = parallellise(block_tile, Tile(conf.compute_warp), warpId, conf.warps_per_block)
+            @loopinfo unroll for warp_tile = parallellise(block_tile, Tile(conf.compute_warp), warpId, conf.warps_per_block)
                 # (3.3.1) Load a compute_warp.M x compute_warp.K tile of A from shared memory into registers
                 a_frags = LocalArray{Tuple{num_fragments_m}, Operator.fragtype_a(conf.operator, conf.shared_a_layout)}(undef)
 
-                @loopinfo unrollfull for i = 1 : num_fragments_m
+                @loopinfo unroll for i = 1 : num_fragments_m
                     a_tile = translate_offset(warp_tile.MK, (M = (i-1)*conf.compute_op_shape.M, K = 0))
                     @inbounds a_frags = setindex(a_frags, transf_sh2rf_a(Operator.load_a(conf.operator, conf.shared_a_layout, shmem_a, a_tile), a_tile), i)
                 end
@@ -94,14 +94,14 @@ function matmul_singlestage(a, b, c, d,
                 # (3.3.2) Load a compute_warp.K x compute_warp.N tile of B from shared memory into registers
                 b_frags = LocalArray{Tuple{num_fragments_n}, Operator.fragtype_b(conf.operator, conf.shared_b_layout)}(undef)
 
-                @loopinfo unrollfull for j = 1 : num_fragments_n
+                @loopinfo unroll for j = 1 : num_fragments_n
                     b_tile = translate_offset(warp_tile.KN, (K = 0, N = (j-1)*conf.compute_op_shape.N))
                     @inbounds b_frags = setindex(b_frags, transf_sh2rf_b(Operator.load_b(conf.operator, conf.shared_b_layout, shmem_b, b_tile), b_tile), j)
                 end
 
                 # (3.3.3) Compute a compute_warp.M x compute_warp.N x compute_warp.K matrix product within one warp
-                @loopinfo unrollfull for i = 1 : num_fragments_m
-                    @loopinfo unrollfull for j = 1 : num_fragments_n
+                @loopinfo unroll for i = 1 : num_fragments_m
+                    @loopinfo unroll for j = 1 : num_fragments_n
                         @inbounds c_frags = setindex(c_frags, Operator.mma(conf.operator, a_frags[i], b_frags[j], c_frags[i, j]), i, j)
                     end
                 end
@@ -116,8 +116,8 @@ function matmul_singlestage(a, b, c, d,
 
     warp_tile = subdivide(block_tile.MN, Tile(conf.compute_warp).MN, warpId, conf.warps_per_block)
 
-    @loopinfo unrollfull for i = 1 : num_fragments_m
-        @loopinfo unrollfull for j = 1 : num_fragments_n
+    @loopinfo unroll for i = 1 : num_fragments_m
+        @loopinfo unroll for j = 1 : num_fragments_n
             tile = translate_offset(warp_tile, (M = (i-1)*conf.compute_op_shape.M, N = (j-1)*conf.compute_op_shape.N))
             @inbounds Operator.store_d(conf.operator, conf.shared_d_layout, shmem_d, transf_rf2sh_d(c_frags[i, j], tile), tile)
         end
@@ -153,8 +153,8 @@ function matmul_pipelined(a, b, c, d,
     # (1) Cooperatively load a block_shape.M x block_shape.N tile of C from global to shared memory within one threadblock
     shmem_c = CuDynamicSharedArray(Layout.eltype(conf.shared_c_layout), Layout.physical_size(conf.shared_c_layout, block_tile.MN.size))
 
-    @loopinfo unrollfull for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
-        @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
+    @loopinfo unroll for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
+        @loopinfo unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
             x = Layout.load(conf.global_c_layout, c, translate_base(thread_tile, (M = block_i, N = block_j)))
             x = transf_gl2sh_c(x, thread_tile)
             Layout.store!(conf.shared_c_layout, shmem_c, x, thread_tile)
@@ -168,8 +168,8 @@ function matmul_pipelined(a, b, c, d,
 
     c_frags = LocalArray{Tuple{num_fragments_m, num_fragments_n}, Operator.fragtype_accum(conf.operator, conf.shared_c_layout)}(undef)
 
-    @loopinfo unrollfull for i = 1 : num_fragments_m
-        @loopinfo unrollfull for j = 1 : num_fragments_n
+    @loopinfo unroll for i = 1 : num_fragments_m
+        @loopinfo unroll for j = 1 : num_fragments_n
             tile = translate_offset(warp_tile, (M = (i-1)*conf.compute_op_shape.M, N = (j-1)*conf.compute_op_shape.N))
             @inbounds c_frags = setindex(c_frags, transf_sh2rf_c(Operator.load_c(conf.operator, conf.shared_c_layout, shmem_c, tile), tile), i, j)
         end
@@ -197,28 +197,28 @@ function matmul_pipelined(a, b, c, d,
     warp_tile_mn = subdivide(block_tile, Tile(conf.compute_warp), warpId, conf.warps_per_block)
 
     # ld.global(0 : block_shape.K)
-    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+    @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+        @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
             @inbounds a_fragment = setindex(a_fragment, Layout.load(conf.global_a_layout, a, translate_base(thread_tile, (M = block_i, K = 0))), i, j)
         end
     end
 
-    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+    @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+        @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
             @inbounds b_fragment = setindex(b_fragment, Layout.load(conf.global_b_layout, b, translate_base(thread_tile, (K = 0, N = block_j))), i, j)
         end
     end
 
     # st.shared()
-    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+    @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+        @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
             @inbounds x = transf_gl2sh_a(a_fragment[i, j], thread_tile)
             Layout.store!(conf.shared_a_layout, shmem_a, x, thread_tile)
         end
     end
 
-    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+    @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+        @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
             @inbounds x = transf_gl2sh_b(b_fragment[i, j], thread_tile)
             Layout.store!(conf.shared_b_layout, shmem_b, x, thread_tile)
         end
@@ -229,31 +229,31 @@ function matmul_pipelined(a, b, c, d,
     # ld.shared(0 : compute_op_shape.K, stage = 1)
     warp_tile = translate_offset(warp_tile_mn, (M = 0, N = 0, K = 0))
 
-    @loopinfo unrollfull for i = 1 : num_fragments_m
+    @loopinfo unroll for i = 1 : num_fragments_m
         a_tile = translate_offset(warp_tile.MK, (M = (i-1)*conf.compute_op_shape.M, K = 0))
         @inbounds a_frags = setindex(a_frags, transf_sh2rf_a(Operator.load_a(conf.operator, conf.shared_a_layout, shmem_a, a_tile), a_tile), 1, i)
     end
 
-    @loopinfo unrollfull for j = 1 : num_fragments_n
+    @loopinfo unroll for j = 1 : num_fragments_n
         b_tile = translate_offset(warp_tile.KN, (K = 0, N = (j-1)*conf.compute_op_shape.N))
         @inbounds b_frags = setindex(b_frags, transf_sh2rf_b(Operator.load_b(conf.operator, conf.shared_b_layout, shmem_b, b_tile), b_tile), 1, j)
     end
 
     # ld.global(block_shape.K : 2 * block_shape.K)
-    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+    @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+        @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
             @inbounds a_fragment = setindex(a_fragment, Layout.load(conf.global_a_layout, a, translate_base(thread_tile, (M = block_i, K = block_tile.size.K))), i, j)
         end
     end
 
-    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+    @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+        @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
             @inbounds b_fragment = setindex(b_fragment, Layout.load(conf.global_b_layout, b, translate_base(thread_tile, (K = block_tile.size.K, N = block_j))), i, j)
         end
     end
 
     @loopinfo unrollcount=1 for block_k = 0 : block_tile.size.K : gemm_sz.size.K - 1
-        @loopinfo unrollfull for (i, warp_k) = enumerate(0 : conf.compute_op_shape.K : block_tile.size.K - 1)
+        @loopinfo unroll for (i, warp_k) = enumerate(0 : conf.compute_op_shape.K : block_tile.size.K - 1)
             cur_stage = mod1(i, 2)
             nxt_stage = mod1(i + 1, 2)
 
@@ -261,15 +261,15 @@ function matmul_pipelined(a, b, c, d,
                 sync_threads()
 
                 # st.shared()
-                @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-                    @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+                @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+                    @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
                         @inbounds x = transf_gl2sh_a(a_fragment[i, j], thread_tile)
                         Layout.store!(conf.shared_a_layout, shmem_a, x, thread_tile)
                     end
                 end
 
-                @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-                    @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+                @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+                    @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
                         @inbounds x = transf_gl2sh_b(b_fragment[i, j], thread_tile)
                         Layout.store!(conf.shared_b_layout, shmem_b, x, thread_tile)
                     end
@@ -280,14 +280,14 @@ function matmul_pipelined(a, b, c, d,
                 # avoid out of bounds access for global memory
                 if block_k < (gemm_sz.size.K - 2 * block_tile.size.K)
                     # ld.global(block_k + 2 * block_shape.K : block_k + 3 * block_shape.K)
-                    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-                        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+                    @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+                        @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
                             @inbounds a_fragment = setindex(a_fragment, Layout.load(conf.global_a_layout, a, translate_base(thread_tile, (M = block_i, K = block_k + 2 * block_tile.size.K))), i, j)
                         end
                     end
 
-                    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-                        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+                    @loopinfo unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+                        @loopinfo unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
                             @inbounds b_fragment = setindex(b_fragment, Layout.load(conf.global_b_layout, b, translate_base(thread_tile, (K = block_k + 2 * block_tile.size.K, N = block_j))), i, j)
                         end
                     end
@@ -297,19 +297,19 @@ function matmul_pipelined(a, b, c, d,
             # ld.shared((warp_k + compute_op_shape.K) % block_shape.K, stage = nxt_stage)
             warp_tile = translate_offset(warp_tile_mn, (M = 0, N = 0, K = (warp_k + conf.compute_op_shape.K) % block_tile.size.K))
 
-            @loopinfo unrollfull for i = 1 : num_fragments_m
+            @loopinfo unroll for i = 1 : num_fragments_m
                 a_tile = translate_offset(warp_tile.MK, (M = (i-1)*conf.compute_op_shape.M, K = 0))
                 @inbounds a_frags = setindex(a_frags, transf_sh2rf_a(Operator.load_a(conf.operator, conf.shared_a_layout, shmem_a, a_tile), a_tile), nxt_stage, i)
             end
 
-            @loopinfo unrollfull for j = 1 : num_fragments_n
+            @loopinfo unroll for j = 1 : num_fragments_n
                 b_tile = translate_offset(warp_tile.KN, (K = 0, N = (j-1)*conf.compute_op_shape.N))
                 @inbounds b_frags = setindex(b_frags, transf_sh2rf_b(Operator.load_b(conf.operator, conf.shared_b_layout, shmem_b, b_tile), b_tile), nxt_stage, j)
             end
 
             # mma(cur_stage)
-            @loopinfo unrollfull for i = 1 : num_fragments_m
-                @loopinfo unrollfull for j = 1 : num_fragments_n
+            @loopinfo unroll for i = 1 : num_fragments_m
+                @loopinfo unroll for j = 1 : num_fragments_n
                     @inbounds c_frags = setindex(c_frags, Operator.mma(conf.operator, a_frags[cur_stage, i], b_frags[cur_stage, j], c_frags[i, j]), i, j)
                 end
             end
@@ -323,8 +323,8 @@ function matmul_pipelined(a, b, c, d,
 
     warp_tile = subdivide(block_tile.MN, Tile(conf.compute_warp).MN, warpId, conf.warps_per_block)
 
-    @loopinfo unrollfull for i = 1 : num_fragments_m
-        @loopinfo unrollfull for j = 1 : num_fragments_n
+    @loopinfo unroll for i = 1 : num_fragments_m
+        @loopinfo unroll for j = 1 : num_fragments_n
             tile = translate_offset(warp_tile, (M = (i-1)*conf.compute_op_shape.M, N = (j-1)*conf.compute_op_shape.N))
             @inbounds Operator.store_d(conf.operator, conf.shared_d_layout, shmem_d, transf_rf2sh_d(c_frags[i, j], tile), tile)
         end

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -5,7 +5,7 @@ using CUDA
 using GemmKernels
 using GemmKernels.Tiling
 using GemmKernels: LocalArray
-using KernelAbstractions.Extras: @unroll
+using LLVMLoopInfo: @loopinfo
 using Base: setindex
 
 function matmul_singlestage(a, b, c, d,
@@ -30,8 +30,8 @@ function matmul_singlestage(a, b, c, d,
     # (1) Cooperatively load a block_shape.M x block_shape.N tile of C from global to shared memory within one threadblock
     shmem_c = CuDynamicSharedArray(Layout.eltype(conf.shared_c_layout), Layout.physical_size(conf.shared_c_layout, block_tile.MN.size))
 
-    @unroll for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
-        @unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
+    @loopinfo unrollfull for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
+        @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
             x = Layout.load(conf.global_c_layout, c, translate_base(thread_tile, (M = block_i, N = block_j)))
             x = transf_gl2sh_c(x, thread_tile)
             Layout.store!(conf.shared_c_layout, shmem_c, x, thread_tile)
@@ -45,8 +45,8 @@ function matmul_singlestage(a, b, c, d,
 
     c_frags = LocalArray{Tuple{num_fragments_m, num_fragments_n}, Operator.fragtype_accum(conf.operator, conf.shared_c_layout)}(undef)
 
-    @unroll for i = 1 : num_fragments_m
-        @unroll for j = 1 : num_fragments_n
+    @loopinfo unrollfull for i = 1 : num_fragments_m
+        @loopinfo unrollfull for j = 1 : num_fragments_n
             tile = translate_offset(warp_tile, (M = (i-1)*conf.compute_op_shape.M, N = (j-1)*conf.compute_op_shape.N))
             @inbounds c_frags = setindex(c_frags, transf_sh2rf_c(Operator.load_c(conf.operator, conf.shared_c_layout, shmem_c, tile), tile), i ,j)
         end
@@ -59,11 +59,11 @@ function matmul_singlestage(a, b, c, d,
     shmem_b = CuDynamicSharedArray(Layout.eltype(conf.shared_b_layout), Layout.physical_size(conf.shared_b_layout, block_tile.KN.size),
                                   length(shmem_a) * sizeof(Layout.eltype(conf.shared_a_layout)))
 
-    @unroll for block_k = 0 : block_tile.size.K : gemm_sz.size.K - 1
+    @loopinfo unrollfull for block_k = 0 : block_tile.size.K : gemm_sz.size.K - 1
         if Layout.threadblock_condition(conf.global_a_layout, conf.global_b_layout, block_i, block_j, block_k, block_tile)
             # (3.1) Cooperatively load a block_shape.M x block_shape.K tile of A from global to shared memory within one threadblock
-            @unroll for warp_tile = parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major)
-                @unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major)
+            @loopinfo unrollfull for warp_tile = parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major)
+                @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major)
                     x = Layout.load(conf.global_a_layout, a, translate_base(thread_tile, (M = block_i, K = block_k)))
                     x = transf_gl2sh_a(x, thread_tile)
                     Layout.store!(conf.shared_a_layout, shmem_a, x, thread_tile)
@@ -71,8 +71,8 @@ function matmul_singlestage(a, b, c, d,
             end
 
             # (3.2) Cooperatively load a block_shape.K x block_shape.N tile of B from global to shared memory within one threadblock
-            @unroll for warp_tile = parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major)
-                @unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major)
+            @loopinfo unrollfull for warp_tile = parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major)
+                @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major)
                     x = Layout.load(conf.global_b_layout, b, translate_base(thread_tile, (K = block_k, N = block_j)))
                     x = transf_gl2sh_b(x, thread_tile)
                     Layout.store!(conf.shared_b_layout, shmem_b, x, thread_tile)
@@ -82,11 +82,11 @@ function matmul_singlestage(a, b, c, d,
             sync_threads()
 
             # (3.3) Calculate a compute_warp.M x compute_warp.N tile of D, using a compute_warp.M x compute_warp.N x compute_warp.K operation
-            @unroll for warp_tile = parallellise(block_tile, Tile(conf.compute_warp), warpId, conf.warps_per_block)
+            @loopinfo unrollfull for warp_tile = parallellise(block_tile, Tile(conf.compute_warp), warpId, conf.warps_per_block)
                 # (3.3.1) Load a compute_warp.M x compute_warp.K tile of A from shared memory into registers
                 a_frags = LocalArray{Tuple{num_fragments_m}, Operator.fragtype_a(conf.operator, conf.shared_a_layout)}(undef)
 
-                @unroll for i = 1 : num_fragments_m
+                @loopinfo unrollfull for i = 1 : num_fragments_m
                     a_tile = translate_offset(warp_tile.MK, (M = (i-1)*conf.compute_op_shape.M, K = 0))
                     @inbounds a_frags = setindex(a_frags, transf_sh2rf_a(Operator.load_a(conf.operator, conf.shared_a_layout, shmem_a, a_tile), a_tile), i)
                 end
@@ -94,14 +94,14 @@ function matmul_singlestage(a, b, c, d,
                 # (3.3.2) Load a compute_warp.K x compute_warp.N tile of B from shared memory into registers
                 b_frags = LocalArray{Tuple{num_fragments_n}, Operator.fragtype_b(conf.operator, conf.shared_b_layout)}(undef)
 
-                @unroll for j = 1 : num_fragments_n
+                @loopinfo unrollfull for j = 1 : num_fragments_n
                     b_tile = translate_offset(warp_tile.KN, (K = 0, N = (j-1)*conf.compute_op_shape.N))
                     @inbounds b_frags = setindex(b_frags, transf_sh2rf_b(Operator.load_b(conf.operator, conf.shared_b_layout, shmem_b, b_tile), b_tile), j)
                 end
 
                 # (3.3.3) Compute a compute_warp.M x compute_warp.N x compute_warp.K matrix product within one warp
-                @unroll for i = 1 : num_fragments_m
-                    @unroll for j = 1 : num_fragments_n
+                @loopinfo unrollfull for i = 1 : num_fragments_m
+                    @loopinfo unrollfull for j = 1 : num_fragments_n
                         @inbounds c_frags = setindex(c_frags, Operator.mma(conf.operator, a_frags[i], b_frags[j], c_frags[i, j]), i, j)
                     end
                 end
@@ -116,8 +116,8 @@ function matmul_singlestage(a, b, c, d,
 
     warp_tile = subdivide(block_tile.MN, Tile(conf.compute_warp).MN, warpId, conf.warps_per_block)
 
-    @unroll for i = 1 : num_fragments_m
-        @unroll for j = 1 : num_fragments_n
+    @loopinfo unrollfull for i = 1 : num_fragments_m
+        @loopinfo unrollfull for j = 1 : num_fragments_n
             tile = translate_offset(warp_tile, (M = (i-1)*conf.compute_op_shape.M, N = (j-1)*conf.compute_op_shape.N))
             @inbounds Operator.store_d(conf.operator, conf.shared_d_layout, shmem_d, transf_rf2sh_d(c_frags[i, j], tile), tile)
         end
@@ -153,8 +153,8 @@ function matmul_pipelined(a, b, c, d,
     # (1) Cooperatively load a block_shape.M x block_shape.N tile of C from global to shared memory within one threadblock
     shmem_c = CuDynamicSharedArray(Layout.eltype(conf.shared_c_layout), Layout.physical_size(conf.shared_c_layout, block_tile.MN.size))
 
-    @unroll for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
-        @unroll for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
+    @loopinfo unrollfull for warp_tile = parallellise(block_tile.MN, Tile(conf.mem_cd_warp), warpId, conf.warps_per_block)
+        @loopinfo unrollfull for thread_tile = parallellise(warp_tile, Tile(conf.mem_cd_thread), laneId, 32)
             x = Layout.load(conf.global_c_layout, c, translate_base(thread_tile, (M = block_i, N = block_j)))
             x = transf_gl2sh_c(x, thread_tile)
             Layout.store!(conf.shared_c_layout, shmem_c, x, thread_tile)
@@ -168,8 +168,8 @@ function matmul_pipelined(a, b, c, d,
 
     c_frags = LocalArray{Tuple{num_fragments_m, num_fragments_n}, Operator.fragtype_accum(conf.operator, conf.shared_c_layout)}(undef)
 
-    @unroll for i = 1 : num_fragments_m
-        @unroll for j = 1 : num_fragments_n
+    @loopinfo unrollfull for i = 1 : num_fragments_m
+        @loopinfo unrollfull for j = 1 : num_fragments_n
             tile = translate_offset(warp_tile, (M = (i-1)*conf.compute_op_shape.M, N = (j-1)*conf.compute_op_shape.N))
             @inbounds c_frags = setindex(c_frags, transf_sh2rf_c(Operator.load_c(conf.operator, conf.shared_c_layout, shmem_c, tile), tile), i, j)
         end
@@ -197,28 +197,28 @@ function matmul_pipelined(a, b, c, d,
     warp_tile_mn = subdivide(block_tile, Tile(conf.compute_warp), warpId, conf.warps_per_block)
 
     # ld.global(0 : block_shape.K)
-    @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-        @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
             @inbounds a_fragment = setindex(a_fragment, Layout.load(conf.global_a_layout, a, translate_base(thread_tile, (M = block_i, K = 0))), i, j)
         end
     end
 
-    @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-        @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
             @inbounds b_fragment = setindex(b_fragment, Layout.load(conf.global_b_layout, b, translate_base(thread_tile, (K = 0, N = block_j))), i, j)
         end
     end
 
     # st.shared()
-    @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-        @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
             @inbounds x = transf_gl2sh_a(a_fragment[i, j], thread_tile)
             Layout.store!(conf.shared_a_layout, shmem_a, x, thread_tile)
         end
     end
 
-    @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-        @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
             @inbounds x = transf_gl2sh_b(b_fragment[i, j], thread_tile)
             Layout.store!(conf.shared_b_layout, shmem_b, x, thread_tile)
         end
@@ -229,31 +229,31 @@ function matmul_pipelined(a, b, c, d,
     # ld.shared(0 : compute_op_shape.K, stage = 1)
     warp_tile = translate_offset(warp_tile_mn, (M = 0, N = 0, K = 0))
 
-    @unroll for i = 1 : num_fragments_m
+    @loopinfo unrollfull for i = 1 : num_fragments_m
         a_tile = translate_offset(warp_tile.MK, (M = (i-1)*conf.compute_op_shape.M, K = 0))
         @inbounds a_frags = setindex(a_frags, transf_sh2rf_a(Operator.load_a(conf.operator, conf.shared_a_layout, shmem_a, a_tile), a_tile), 1, i)
     end
 
-    @unroll for j = 1 : num_fragments_n
+    @loopinfo unrollfull for j = 1 : num_fragments_n
         b_tile = translate_offset(warp_tile.KN, (K = 0, N = (j-1)*conf.compute_op_shape.N))
         @inbounds b_frags = setindex(b_frags, transf_sh2rf_b(Operator.load_b(conf.operator, conf.shared_b_layout, shmem_b, b_tile), b_tile), 1, j)
     end
 
     # ld.global(block_shape.K : 2 * block_shape.K)
-    @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-        @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
             @inbounds a_fragment = setindex(a_fragment, Layout.load(conf.global_a_layout, a, translate_base(thread_tile, (M = block_i, K = block_tile.size.K))), i, j)
         end
     end
 
-    @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-        @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
             @inbounds b_fragment = setindex(b_fragment, Layout.load(conf.global_b_layout, b, translate_base(thread_tile, (K = block_tile.size.K, N = block_j))), i, j)
         end
     end
 
-    @unroll 1 for block_k = 0 : block_tile.size.K : gemm_sz.size.K - 1
-        @unroll for (i, warp_k) = enumerate(0 : conf.compute_op_shape.K : block_tile.size.K - 1)
+    @loopinfo unrollcount=1 for block_k = 0 : block_tile.size.K : gemm_sz.size.K - 1
+        @loopinfo unrollfull for (i, warp_k) = enumerate(0 : conf.compute_op_shape.K : block_tile.size.K - 1)
             cur_stage = mod1(i, 2)
             nxt_stage = mod1(i + 1, 2)
 
@@ -261,15 +261,15 @@ function matmul_pipelined(a, b, c, d,
                 sync_threads()
 
                 # st.shared()
-                @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-                    @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+                @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+                    @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
                         @inbounds x = transf_gl2sh_a(a_fragment[i, j], thread_tile)
                         Layout.store!(conf.shared_a_layout, shmem_a, x, thread_tile)
                     end
                 end
 
-                @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-                    @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+                @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+                    @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
                         @inbounds x = transf_gl2sh_b(b_fragment[i, j], thread_tile)
                         Layout.store!(conf.shared_b_layout, shmem_b, x, thread_tile)
                     end
@@ -280,14 +280,14 @@ function matmul_pipelined(a, b, c, d,
                 # avoid out of bounds access for global memory
                 if block_k < (gemm_sz.size.K - 2 * block_tile.size.K)
                     # ld.global(block_k + 2 * block_shape.K : block_k + 3 * block_shape.K)
-                    @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
-                        @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
+                    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.MK, Tile(conf.mem_a_warp), warpId, conf.warps_per_block, conf.is_a_col_major))
+                        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_a_thread), laneId, 32, conf.is_a_col_major))
                             @inbounds a_fragment = setindex(a_fragment, Layout.load(conf.global_a_layout, a, translate_base(thread_tile, (M = block_i, K = block_k + 2 * block_tile.size.K))), i, j)
                         end
                     end
 
-                    @unroll for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
-                        @unroll for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
+                    @loopinfo unrollfull for (i, warp_tile) = enumerate(parallellise(block_tile.KN, Tile(conf.mem_b_warp), warpId, conf.warps_per_block, conf.is_b_col_major))
+                        @loopinfo unrollfull for (j, thread_tile) = enumerate(parallellise(warp_tile, Tile(conf.mem_b_thread), laneId, 32, conf.is_b_col_major))
                             @inbounds b_fragment = setindex(b_fragment, Layout.load(conf.global_b_layout, b, translate_base(thread_tile, (K = block_k + 2 * block_tile.size.K, N = block_j))), i, j)
                         end
                     end
@@ -297,19 +297,19 @@ function matmul_pipelined(a, b, c, d,
             # ld.shared((warp_k + compute_op_shape.K) % block_shape.K, stage = nxt_stage)
             warp_tile = translate_offset(warp_tile_mn, (M = 0, N = 0, K = (warp_k + conf.compute_op_shape.K) % block_tile.size.K))
 
-            @unroll for i = 1 : num_fragments_m
+            @loopinfo unrollfull for i = 1 : num_fragments_m
                 a_tile = translate_offset(warp_tile.MK, (M = (i-1)*conf.compute_op_shape.M, K = 0))
                 @inbounds a_frags = setindex(a_frags, transf_sh2rf_a(Operator.load_a(conf.operator, conf.shared_a_layout, shmem_a, a_tile), a_tile), nxt_stage, i)
             end
 
-            @unroll for j = 1 : num_fragments_n
+            @loopinfo unrollfull for j = 1 : num_fragments_n
                 b_tile = translate_offset(warp_tile.KN, (K = 0, N = (j-1)*conf.compute_op_shape.N))
                 @inbounds b_frags = setindex(b_frags, transf_sh2rf_b(Operator.load_b(conf.operator, conf.shared_b_layout, shmem_b, b_tile), b_tile), nxt_stage, j)
             end
 
             # mma(cur_stage)
-            @unroll for i = 1 : num_fragments_m
-                @unroll for j = 1 : num_fragments_n
+            @loopinfo unrollfull for i = 1 : num_fragments_m
+                @loopinfo unrollfull for j = 1 : num_fragments_n
                     @inbounds c_frags = setindex(c_frags, Operator.mma(conf.operator, a_frags[cur_stage, i], b_frags[cur_stage, j], c_frags[i, j]), i, j)
                 end
             end
@@ -323,8 +323,8 @@ function matmul_pipelined(a, b, c, d,
 
     warp_tile = subdivide(block_tile.MN, Tile(conf.compute_warp).MN, warpId, conf.warps_per_block)
 
-    @unroll for i = 1 : num_fragments_m
-        @unroll for j = 1 : num_fragments_n
+    @loopinfo unrollfull for i = 1 : num_fragments_m
+        @loopinfo unrollfull for j = 1 : num_fragments_n
             tile = translate_offset(warp_tile, (M = (i-1)*conf.compute_op_shape.M, N = (j-1)*conf.compute_op_shape.N))
             @inbounds Operator.store_d(conf.operator, conf.shared_d_layout, shmem_d, transf_rf2sh_d(c_frags[i, j], tile), tile)
         end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -144,8 +144,8 @@ abstract type InterleavedColMajor{T} <: LayoutBase{T} end
 @inline function load(::Type{<:InterleavedColMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     x = ntuple(i -> zero(Complex{T}), tile.size[1] * tile.size[2])
 
-    @loopinfo unrollfull for j = 1 : tile.size[2]
-        @loopinfo unrollfull for i = 1 : tile.size[1]
+    @loopinfo unroll for j = 1 : tile.size[2]
+        @loopinfo unroll for i = 1 : tile.size[1]
             t = translate_offset(tile, (i - 1, j - 1))
             @inbounds val = workspace[t.index[1] + 1, t.index[2] + 1]
             x = Base.setindex(x, val, (i - 1) * tile.size[2] + j)
@@ -156,8 +156,8 @@ abstract type InterleavedColMajor{T} <: LayoutBase{T} end
 end
 
 @inline function store!(::Type{<:InterleavedColMajor{T}}, workspace, value, tile::Tile{size}) where {T, size}
-    @loopinfo unrollfull for j = 1 : tile.size[2]
-        @loopinfo unrollfull for i = 1 : tile.size[1]
+    @loopinfo unroll for j = 1 : tile.size[2]
+        @loopinfo unroll for i = 1 : tile.size[1]
             t = translate_offset(tile, (i - 1, j - 1))
             val = value[(i - 1) * tile.size[2] + j]
             @inbounds workspace[t.index[1] + 1, t.index[2] + 1] = val
@@ -176,8 +176,8 @@ abstract type InterleavedRowMajor{T} <: LayoutBase{T} end
 @inline function load(::Type{<:InterleavedRowMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     x = ntuple(i -> zero(Complex{T}), tile.size[1] * tile.size[2])
 
-    @loopinfo unrollfull for i = 1 : tile.size[1]
-        @loopinfo unrollfull for j = 1 : tile.size[2]
+    @loopinfo unroll for i = 1 : tile.size[1]
+        @loopinfo unroll for j = 1 : tile.size[2]
             t = translate_offset(tile, (i - 1, j - 1))
             @inbounds val = workspace[t.index[2] + 1, t.index[1] + 1]
             x = Base.setindex(x, val, (i - 1) * tile.size[2] + j)
@@ -188,8 +188,8 @@ abstract type InterleavedRowMajor{T} <: LayoutBase{T} end
 end
 
 @inline function store!(::Type{<:InterleavedRowMajor{T}}, workspace, value, tile::Tile{size}) where {T, size}
-    @loopinfo unrollfull for i = 1 : tile.size[1]
-        @loopinfo unrollfull for j = 1 : tile.size[2]
+    @loopinfo unroll for i = 1 : tile.size[1]
+        @loopinfo unroll for j = 1 : tile.size[2]
             t = translate_offset(tile, (i - 1, j - 1))
             val = value[(i - 1) * tile.size[2] + j]
             @inbounds workspace[t.index[2] + 1, t.index[1] + 1] = val
@@ -213,8 +213,8 @@ end
 @inline function load(::Type{<:SplitColMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     x = ntuple(i -> zero(Complex{T}), tile.size[1] * tile.size[2])
 
-    @loopinfo unrollfull for j = 1 : tile.size[2]
-        @loopinfo unrollfull for i = 1 : tile.size[1]
+    @loopinfo unroll for j = 1 : tile.size[2]
+        @loopinfo unroll for i = 1 : tile.size[1]
             t = translate_offset(tile, (i - 1, j - 1))
             @inbounds val = workspace[t.index[1] + 1, t.index[2] + 1, 1] + im *
                             workspace[t.index[1] + 1, t.index[2] + 1, 2]
@@ -226,8 +226,8 @@ end
 end
 
 @inline function store!(::Type{<:SplitColMajor{T}}, workspace, value, tile::Tile{size}) where {T, size}
-    @loopinfo unrollfull for j = 1 : tile.size[2]
-        @loopinfo unrollfull for i = 1 : tile.size[1]
+    @loopinfo unroll for j = 1 : tile.size[2]
+        @loopinfo unroll for i = 1 : tile.size[1]
             t = translate_offset(tile, (i - 1, j - 1))
             val = value[(i - 1) * tile.size[2] + j]
             @inbounds workspace[t.index[1] + 1, t.index[2] + 1, 1] = val.re
@@ -251,8 +251,8 @@ end
 @inline function load(::Type{<:SplitRowMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     x = ntuple(i -> zero(Complex{T}), tile.size[1] * tile.size[2])
 
-    @loopinfo unrollfull for i = 1 : tile.size[1]
-        @loopinfo unrollfull for j = 1 : tile.size[2]
+    @loopinfo unroll for i = 1 : tile.size[1]
+        @loopinfo unroll for j = 1 : tile.size[2]
             t = translate_offset(tile, (i - 1, j - 1))
             @inbounds val = workspace[t.index[2] + 1, t.index[1] + 1, 1] + im *
                             workspace[t.index[2] + 1, t.index[1] + 1, 2]
@@ -264,8 +264,8 @@ end
 end
 
 @inline function store!(::Type{<:SplitRowMajor{T}}, workspace, value, tile::Tile{size}) where {T, size}
-    @loopinfo unrollfull for i = 1 : tile.size[1]
-        @loopinfo unrollfull for j = 1 : tile.size[2]
+    @loopinfo unroll for i = 1 : tile.size[1]
+        @loopinfo unroll for j = 1 : tile.size[2]
             t = translate_offset(tile, (i - 1, j - 1))
             val = value[(i - 1) * tile.size[2] + j]
             @inbounds workspace[t.index[2] + 1, t.index[1] + 1, 1] = val.re

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -2,7 +2,7 @@ export Layout
 module Layout
 
 using CUDA
-using KernelAbstractions.Extras: @unroll
+using LLVMLoopInfo: @loopinfo
 using GemmKernels.Tiling
 
 # ---------------------
@@ -144,8 +144,8 @@ abstract type InterleavedColMajor{T} <: LayoutBase{T} end
 @inline function load(::Type{<:InterleavedColMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     x = ntuple(i -> zero(Complex{T}), tile.size[1] * tile.size[2])
 
-    @unroll for j = 1 : tile.size[2]
-        @unroll for i = 1 : tile.size[1]
+    @loopinfo unrollfull for j = 1 : tile.size[2]
+        @loopinfo unrollfull for i = 1 : tile.size[1]
             t = translate_offset(tile, (i - 1, j - 1))
             @inbounds val = workspace[t.index[1] + 1, t.index[2] + 1]
             x = Base.setindex(x, val, (i - 1) * tile.size[2] + j)
@@ -156,8 +156,8 @@ abstract type InterleavedColMajor{T} <: LayoutBase{T} end
 end
 
 @inline function store!(::Type{<:InterleavedColMajor{T}}, workspace, value, tile::Tile{size}) where {T, size}
-    @unroll for j = 1 : tile.size[2]
-        @unroll for i = 1 : tile.size[1]
+    @loopinfo unrollfull for j = 1 : tile.size[2]
+        @loopinfo unrollfull for i = 1 : tile.size[1]
             t = translate_offset(tile, (i - 1, j - 1))
             val = value[(i - 1) * tile.size[2] + j]
             @inbounds workspace[t.index[1] + 1, t.index[2] + 1] = val
@@ -176,8 +176,8 @@ abstract type InterleavedRowMajor{T} <: LayoutBase{T} end
 @inline function load(::Type{<:InterleavedRowMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     x = ntuple(i -> zero(Complex{T}), tile.size[1] * tile.size[2])
 
-    @unroll for i = 1 : tile.size[1]
-        @unroll for j = 1 : tile.size[2]
+    @loopinfo unrollfull for i = 1 : tile.size[1]
+        @loopinfo unrollfull for j = 1 : tile.size[2]
             t = translate_offset(tile, (i - 1, j - 1))
             @inbounds val = workspace[t.index[2] + 1, t.index[1] + 1]
             x = Base.setindex(x, val, (i - 1) * tile.size[2] + j)
@@ -188,8 +188,8 @@ abstract type InterleavedRowMajor{T} <: LayoutBase{T} end
 end
 
 @inline function store!(::Type{<:InterleavedRowMajor{T}}, workspace, value, tile::Tile{size}) where {T, size}
-    @unroll for i = 1 : tile.size[1]
-        @unroll for j = 1 : tile.size[2]
+    @loopinfo unrollfull for i = 1 : tile.size[1]
+        @loopinfo unrollfull for j = 1 : tile.size[2]
             t = translate_offset(tile, (i - 1, j - 1))
             val = value[(i - 1) * tile.size[2] + j]
             @inbounds workspace[t.index[2] + 1, t.index[1] + 1] = val
@@ -213,8 +213,8 @@ end
 @inline function load(::Type{<:SplitColMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     x = ntuple(i -> zero(Complex{T}), tile.size[1] * tile.size[2])
 
-    @unroll for j = 1 : tile.size[2]
-        @unroll for i = 1 : tile.size[1]
+    @loopinfo unrollfull for j = 1 : tile.size[2]
+        @loopinfo unrollfull for i = 1 : tile.size[1]
             t = translate_offset(tile, (i - 1, j - 1))
             @inbounds val = workspace[t.index[1] + 1, t.index[2] + 1, 1] + im *
                             workspace[t.index[1] + 1, t.index[2] + 1, 2]
@@ -226,8 +226,8 @@ end
 end
 
 @inline function store!(::Type{<:SplitColMajor{T}}, workspace, value, tile::Tile{size}) where {T, size}
-    @unroll for j = 1 : tile.size[2]
-        @unroll for i = 1 : tile.size[1]
+    @loopinfo unrollfull for j = 1 : tile.size[2]
+        @loopinfo unrollfull for i = 1 : tile.size[1]
             t = translate_offset(tile, (i - 1, j - 1))
             val = value[(i - 1) * tile.size[2] + j]
             @inbounds workspace[t.index[1] + 1, t.index[2] + 1, 1] = val.re
@@ -251,8 +251,8 @@ end
 @inline function load(::Type{<:SplitRowMajor{T}}, workspace, tile::Tile{size}) where {T, size}
     x = ntuple(i -> zero(Complex{T}), tile.size[1] * tile.size[2])
 
-    @unroll for i = 1 : tile.size[1]
-        @unroll for j = 1 : tile.size[2]
+    @loopinfo unrollfull for i = 1 : tile.size[1]
+        @loopinfo unrollfull for j = 1 : tile.size[2]
             t = translate_offset(tile, (i - 1, j - 1))
             @inbounds val = workspace[t.index[2] + 1, t.index[1] + 1, 1] + im *
                             workspace[t.index[2] + 1, t.index[1] + 1, 2]
@@ -264,8 +264,8 @@ end
 end
 
 @inline function store!(::Type{<:SplitRowMajor{T}}, workspace, value, tile::Tile{size}) where {T, size}
-    @unroll for i = 1 : tile.size[1]
-        @unroll for j = 1 : tile.size[2]
+    @loopinfo unrollfull for i = 1 : tile.size[1]
+        @loopinfo unrollfull for j = 1 : tile.size[2]
             t = translate_offset(tile, (i - 1, j - 1))
             val = value[(i - 1) * tile.size[2] + j]
             @inbounds workspace[t.index[2] + 1, t.index[1] + 1, 1] = val.re

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -5,7 +5,7 @@ using CUDA
 using GemmKernels
 using GemmKernels.Tiling
 using GemmKernels: LocalArray
-using KernelAbstractions.Extras: @unroll
+using LLVMLoopInfo: @loopinfo
 using Base: setindex
 
 # -------------------------------------
@@ -44,13 +44,13 @@ for (layout_type, convert_index_func) in [
             y, x = (tile.base.M + tile.offset.M + op_y, tile.base.K + tile.offset.K + 1)
 
             frag = LocalArray{Tuple{M ÷ 4, K}, CT}(undef)
-            @unroll for m = 1 : M ÷ 4
-                @unroll for k = 1 : K
+            @loopinfo unrollfull for m = 1 : M ÷ 4
+                @loopinfo unrollfull for k = 1 : K
                     y_layout, x_layout = $convert_index_func((y + 4 * (m - 1), x + (k - 1)))
                     @inbounds frag = setindex(frag, CT(workspace[y_layout, x_layout]), m, k)
                 end
             end
-            
+
             return NTuple{M * K ÷ 4, CT}(frag)
         end
 
@@ -61,8 +61,8 @@ for (layout_type, convert_index_func) in [
             y, x = (tile.base.K + tile.offset.K + 1, tile.base.N + tile.offset.N + op_x)
 
             frag = LocalArray{Tuple{K, N ÷ 8}, CT}(undef)
-            @unroll for n = 1 : N ÷ 8
-                @unroll for k = 1 : K
+            @loopinfo unrollfull for n = 1 : N ÷ 8
+                @loopinfo unrollfull for k = 1 : K
                     y_layout, x_layout = $convert_index_func((y + (k - 1), x + 8 * (n - 1)))
                     @inbounds frag = setindex(frag, CT(workspace[y_layout, x_layout]), k, n)
                 end
@@ -80,8 +80,8 @@ for (layout_type, convert_index_func) in [
             y, x = (tile.base.M + tile.offset.M + op_y, tile.base.N + tile.offset.N + op_x)
 
             frag = LocalArray{Tuple{M ÷ 4, N ÷ 8}, DT}(undef)
-            @unroll for m = 1 : M ÷ 4
-                @unroll for n = 1 : N ÷ 8 
+            @loopinfo unrollfull for m = 1 : M ÷ 4
+                @loopinfo unrollfull for n = 1 : N ÷ 8
                     @inbounds frag = setindex(frag, DT(workspace[y + 4 * (m - 1), x + 8 * (n - 1)]), m, n)
                 end
             end
@@ -98,8 +98,8 @@ for (layout_type, convert_index_func) in [
             y, x = (tile.base.M + tile.offset.M + op_y, tile.base.N + tile.offset.N + op_x)
 
             frag = LocalArray{Tuple{M ÷ 4, N ÷ 8}, DT}(frag)
-            @unroll for m = 1 : M ÷ 4
-                @unroll for n = 1 : N ÷ 8 
+            @loopinfo unrollfull for m = 1 : M ÷ 4
+                @loopinfo unrollfull for n = 1 : N ÷ 8
                     @inbounds workspace[y + 4 * (m - 1), x + 8 * (n - 1)] = frag[m, n]
                 end
             end
@@ -122,9 +122,9 @@ end
     b_frag = LocalArray{Tuple{K, N ÷ 8}, CT}(b_frag)
     c_frag = LocalArray{Tuple{M ÷ 4, N ÷ 8}, DT}(c_frag)
 
-    @unroll for m = 1 : M ÷ 4
-        @unroll for n = 1 : N ÷ 8 
-            @unroll for k = 1 : K
+    @loopinfo unrollfull for m = 1 : M ÷ 4
+        @loopinfo unrollfull for n = 1 : N ÷ 8
+            @loopinfo unrollfull for k = 1 : K
                 @inbounds c_frag = setindex(
                     c_frag,
                     operator_fma(operator_type, a_frag[m, k], b_frag[k, n], c_frag[m, n]),

--- a/src/operator.jl
+++ b/src/operator.jl
@@ -44,8 +44,8 @@ for (layout_type, convert_index_func) in [
             y, x = (tile.base.M + tile.offset.M + op_y, tile.base.K + tile.offset.K + 1)
 
             frag = LocalArray{Tuple{M ÷ 4, K}, CT}(undef)
-            @loopinfo unrollfull for m = 1 : M ÷ 4
-                @loopinfo unrollfull for k = 1 : K
+            @loopinfo unroll for m = 1 : M ÷ 4
+                @loopinfo unroll for k = 1 : K
                     y_layout, x_layout = $convert_index_func((y + 4 * (m - 1), x + (k - 1)))
                     @inbounds frag = setindex(frag, CT(workspace[y_layout, x_layout]), m, k)
                 end
@@ -61,8 +61,8 @@ for (layout_type, convert_index_func) in [
             y, x = (tile.base.K + tile.offset.K + 1, tile.base.N + tile.offset.N + op_x)
 
             frag = LocalArray{Tuple{K, N ÷ 8}, CT}(undef)
-            @loopinfo unrollfull for n = 1 : N ÷ 8
-                @loopinfo unrollfull for k = 1 : K
+            @loopinfo unroll for n = 1 : N ÷ 8
+                @loopinfo unroll for k = 1 : K
                     y_layout, x_layout = $convert_index_func((y + (k - 1), x + 8 * (n - 1)))
                     @inbounds frag = setindex(frag, CT(workspace[y_layout, x_layout]), k, n)
                 end
@@ -80,8 +80,8 @@ for (layout_type, convert_index_func) in [
             y, x = (tile.base.M + tile.offset.M + op_y, tile.base.N + tile.offset.N + op_x)
 
             frag = LocalArray{Tuple{M ÷ 4, N ÷ 8}, DT}(undef)
-            @loopinfo unrollfull for m = 1 : M ÷ 4
-                @loopinfo unrollfull for n = 1 : N ÷ 8
+            @loopinfo unroll for m = 1 : M ÷ 4
+                @loopinfo unroll for n = 1 : N ÷ 8
                     @inbounds frag = setindex(frag, DT(workspace[y + 4 * (m - 1), x + 8 * (n - 1)]), m, n)
                 end
             end
@@ -98,8 +98,8 @@ for (layout_type, convert_index_func) in [
             y, x = (tile.base.M + tile.offset.M + op_y, tile.base.N + tile.offset.N + op_x)
 
             frag = LocalArray{Tuple{M ÷ 4, N ÷ 8}, DT}(frag)
-            @loopinfo unrollfull for m = 1 : M ÷ 4
-                @loopinfo unrollfull for n = 1 : N ÷ 8
+            @loopinfo unroll for m = 1 : M ÷ 4
+                @loopinfo unroll for n = 1 : N ÷ 8
                     @inbounds workspace[y + 4 * (m - 1), x + 8 * (n - 1)] = frag[m, n]
                 end
             end
@@ -122,9 +122,9 @@ end
     b_frag = LocalArray{Tuple{K, N ÷ 8}, CT}(b_frag)
     c_frag = LocalArray{Tuple{M ÷ 4, N ÷ 8}, DT}(c_frag)
 
-    @loopinfo unrollfull for m = 1 : M ÷ 4
-        @loopinfo unrollfull for n = 1 : N ÷ 8
-            @loopinfo unrollfull for k = 1 : K
+    @loopinfo unroll for m = 1 : M ÷ 4
+        @loopinfo unroll for n = 1 : N ÷ 8
+            @loopinfo unroll for k = 1 : K
                 @inbounds c_frag = setindex(
                     c_frag,
                     operator_fma(operator_type, a_frag[m, k], b_frag[k, n], c_frag[m, n]),


### PR DESCRIPTION
Closes https://github.com/JuliaGPU/GemmKernels.jl/issues/104.

AFAICT the old `@unroll` from https://github.com/JuliaGPU/KernelAbstractions.jl/blob/95262067fc347713390591d25d79c2885e13f4be/src/extras/loopinfo.jl#L35-L44 was a "full" unroll. Maybe it's better to use plain unroll `unroll` from https://reviews.llvm.org/D11738:

> This change adds the new unroll metadata "llvm.loop.unroll.enable" which directs
> the optimizer to unroll a loop fully if the trip count is known at compile time, and
> unroll partially if the trip count is not known at compile time. This differs from
> "llvm.loop.unroll.full" which explicitly does not unroll a loop if the trip count is not
> known at compile time