### PR TITLE
Make vectorized store convert and perform multiple stores if required

### DIFF
--- a/src/layout.jl
+++ b/src/layout.jl
@@ -4,6 +4,7 @@ module Layout
 using CUDA
 using LLVMLoopInfo: @loopinfo
 using GemmKernels.Tiling
+using Base.Cartesian: @ntuple
 
 # ---------------------
 # Customise computation
@@ -30,8 +31,9 @@ end
     alignment = sizeof(T) * N
 
     return quote
+        y = @ntuple $N i -> VecElement{T}(x[i].value)
         vec_ptr = Base.bitcast(Core.LLVMPtr{NTuple{N, VecElement{T}}, AS}, ptr)
-        return unsafe_store!(vec_ptr, x, (i-1) ÷ N + 1, Val($alignment))
+        return unsafe_store!(vec_ptr, y, (i-1) ÷ N + 1, Val($alignment))
     end
 end
 


### PR DESCRIPTION
Similarly to https://github.com/JuliaGPU/GemmKernels.jl/pull/109, when doing a vectorized store, convert the elements so that they match the element type of the layout. In addition, if we want to store more values than what we can using a single vectorized store, perform multiple stores.

This matters when the element type of the global layout differs from the shared layout. For example, if `global_layout` is `AlignedColMajor{Float16}`, but `shared_layout_a` is `AlignedColMajor{Float32}`, we initially load 8 Float16's, but then only store 4 values into the Float32 shared-memory workspace, because the number of elements is currently always computed as `16 ÷ sizeof(T)`.

The above happens when doing Float16xFloat32, in which case I'm trying to use `T=promote_type(Float16, Float32)=Float32`, causing a type mismatch between global and shared memory. I want to take this approach (as opposed to keeping the shared layout Float16 too) because this opens up a path to using WMMA for incompatible inputs (say, for `Float16xFloat32` we could then use WMMA on a GPU that has `Float32xFloat32=...` tensor cores).