### PR TITLE
Unify WMMA and FPU operator typevars [NFC]

### DIFF
--- a/src/blas.jl
+++ b/src/blas.jl
@@ -52,9 +52,10 @@ function gemmEx!(transA::Char, transB::Char, alpha::Number, A::CuMatrix, B::CuMa
     ## outputs are never transposed, and padding them doesn't seem worth it
     shared_c_layout = shared_d_layout = Layout.AlignedColMajor{eltype(C)}
 
+    compute_type = promote_type(eltype(A), eltype(B))
     conf = GemmKernels.get_config(;
             gemm_shape = (M = m, N = n, K = k),
-            operator = Operator.WMMAOp{16, 16, 16, eltype(C)},
+            operator = Operator.WMMAOp{16, 16, 16, compute_type, eltype(C)},
 
             global_a_layout, global_b_layout, global_c_layout, global_d_layout,
             shared_a_layout, shared_b_layout, shared_c_layout, shared_d_layout,


### PR DESCRIPTION
The WMMA operator only had a T typevar for the accumulator type, while the FPU operator had DT for the destination type and CT for the compute type. Unify that by adding both compute type (CT) and accumulator type (AT) typevars that indicate the type that should be used for the register-level storage and operations.

Note that the WMMA operator's typevars are actually not useful, and should match the eltype of the shared memory (as we use WMMA intrinsics to load/store shared memory, so cannot convert between shared memory and registers). However, we need the accumulator typevar as it cannot be inferred from arguments at some points, so I decided to add the compute typevar too for alignment with the FPU operator.