### PR TITLE
Restrict scope of VecElement usage.

### DIFF
--- a/src/epilogue.jl
+++ b/src/epilogue.jl
@@ -48,7 +48,7 @@ end
     col = thread_tile.index.N + 1
     b = unsafe_load(dev_ptr, col)
 
-    return ntuple(k -> VecElement{Float32}(x[k].value + b), Val(4))
+    return ntuple(k -> Float32(x[k] + b), Val(4))
 end
 
 @inline function (ep::Bias{B})(d, shmem_d, transform, ::Type{conf}) where {B, conf <: GemmKernels.Config}

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -25,8 +25,4 @@ end
 
 @inline (transf::Elementwise)(x, tile) = transf.func.(x)
 
-# when dealing with tuples of VecElements, transform the contained values
-@inline (transf::Elementwise)(x::NTuple{N, <:VecElement}, tile) where {N} =
-    ntuple(i->VecElement(transf.func(x[i].value)), Val(N))
-
 end


### PR DESCRIPTION
We only really need it around vectorized `llvmcall`s. In principle, using it throughout could allow the compiler to optimize storage, but I'm not sure that's the case. Benchmarks will tell.