### PR TITLE
BLAS: Convert alpha & beta to more appropriate types.

### DIFF
--- a/src/blas.jl
+++ b/src/blas.jl
@@ -64,11 +64,14 @@ function gemmEx!(transA::Char, transB::Char, alpha::Number, A::CuMatrix, B::CuMa
             is_b_col_major = !transpose_b
                                 )
 
+    alpha = convert(compute_type, alpha)
+    beta = convert(eltype(C), beta)
     GemmKernels.matmul(A, B, C, C, conf;
                        transform_shared_to_regs_a = Transform.Elementwise(x -> x * alpha),
                        transform_shared_to_regs_c = Transform.Elementwise(x -> x * beta),
                        kernel = kernel(global_a_layout, global_b_layout)
                       )
+    C
 end
 
 end


### PR DESCRIPTION
Default boolean values for `alpha` and `beta` cause messy conversions when applied to e.g. Float16:

```julia
┌ @ /home/tim/Julia/pkg/GemmKernels/src/blas.jl:71 within `#9`
│ %6097  = Core.getfield(%6096, :alpha)::Bool
│┌ @ bool.jl:182 within `*` @ bool.jl:180
││┌ @ number.jl:221 within `copysign`
│││┌ @ floatfuncs.jl:17 within `signbit`
││││ %6098  = Base.bitcast(Base.Int16, %6063)::Int16
││││ @ floatfuncs.jl:17 within `signbit` @ int.jl:139
││││┌ @ promotion.jl:450 within `<`
│││││┌ @ promotion.jl:381 within `promote`
││││││┌ @ promotion.jl:358 within `_promote`
│││││││┌ @ number.jl:7 within `convert`
││││││││┌ @ boot.jl:784 within `Int64`
│││││││││┌ @ boot.jl:702 within `toInt64`
││││││││││ %6099  = Core.sext_int(Core.Int64, %6098)::Int64
│││││└└└└└
│││││ @ promotion.jl:450 within `<` @ int.jl:83
│││││ %6100  = Base.slt_int(%6099, 0)::Bool
│││└└
│││┌ @ operators.jl:269 within `!=`
││││┌ @ promotion.jl:499 within `==`
│││││ %6101  = (false === %6100)::Bool
││││└
││││┌ @ bool.jl:35 within `!`
│││││ %6102  = Base.not_int(%6101)::Bool
│││└└
│││┌ @ essentials.jl:575 within `ifelse`
││││ %6103  = Core.ifelse(%6102, Float16(-0.0), Float16(0.0))::Float16
││└└
││┌ @ essentials.jl:575 within `ifelse`
│││ %6104  = Core.ifelse(%6097, %6063, %6103)::Float16
│└└
```

vs simply

```
┌ @ /home/tim/Julia/pkg/GemmKernels/src/blas.jl:71 within `#13`
│ %6097  = Core.getfield(%6096, :alpha)::Float16
│┌ @ float.jl:410 within `*`
││ %6098  = Base.mul_float(%6063, %6097)::Float16
│└
```

LLVM IR:

```llvm
julia> @code_llvm Float16(1) * true
;  @ bool.jl:182 within `*`
define half @"julia_*_146"(half %0, i8 zeroext %1) #0 {
top:
;  @ bool.jl:182 within `*` @ bool.jl:180
; ┌ @ number.jl:221 within `copysign`
; │┌ @ essentials.jl:575 within `ifelse`
    %2 = call half @llvm.copysign.f16(half 0xH0000, half %0)
; └└
; ┌ @ essentials.jl:575 within `ifelse`
   %3 = and i8 %1, 1
   %.not = icmp eq i8 %3, 0
   %4 = select i1 %.not, half %2, half %0
; └
;  @ bool.jl:182 within `*`
  ret half %4
}
```

Avoiding this reduces register pressure by 15% or so.
