### PR TITLE
Simplify config definition and usage.

### DIFF
--- a/examples/simple_matmul.jl
+++ b/examples/simple_matmul.jl
@@ -50,7 +50,7 @@ function main()
         is_b_col_major = true
     )
 
-    GemmKernels.matmul(A, B, C, parent(C), conf; kernel)
+    GemmKernels.matmul(conf, A, B, C, C; kernel)
 
     @assert Array(C) ≈ Array(A) * Array(B)
 end

--- a/src/GemmKernels.jl
+++ b/src/GemmKernels.jl
@@ -6,6 +6,7 @@ using LinearAlgebra
 # utilities
 include("tiling.jl")
 include("array.jl")
+include("utils.jl")
 
 # framework
 include("config.jl")

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,97 +1,38 @@
-struct Config{
+@staticdef struct Config
     #= Params =#
-    MATMUL_SHAPE,               # MNK, overall shape of the MATMUL operation
-    BLOCK_SHAPE,                # MNK, shape of each CTA tile
-    WARPS_PER_BLOCK,            # scalar, number of warps per CTA
+    matmul_shape                # MNK, overall shape of the MATMUL operation
+    block_shape                 # MNK, shape of each CTA tile
+    warps_per_block             # scalar, number of warps per CTA
 
-    MEM_A_WARP,                 # MK, shape of each warp tile during memory operations involving matrix A
-    MEM_A_THREAD,               # MK, shape of each thread tile during memory operations involving matrix A
+    mem_a_warp                  # MK, shape of each warp tile during memory operations involving matrix A
+    mem_a_thread                # MK, shape of each thread tile during memory operations involving matrix A
 
-    MEM_B_WARP,                 # KN, shape of each warp tile during memory operations involving matrix B
-    MEM_B_THREAD,               # KN, shape of each thread tile during memory operations involving matrix B
+    mem_b_warp                  # KN, shape of each warp tile during memory operations involving matrix B
+    mem_b_thread                # KN, shape of each thread tile during memory operations involving matrix B
 
-    MEM_CD_WARP,                # MN, shape of each warp tile during memory operations involving matrix C or D
-    MEM_CD_THREAD,              # MN, shape of each thread tile during memory operations involving matrix C or D
+    mem_cd_warp                 # MN, shape of each warp tile during memory operations involving matrix C or D
+    mem_cd_thread               # MN, shape of each thread tile during memory operations involving matrix C or D
 
-    COMPUTE_WARP,               # MNK, shape of each warp tile during the inner loop computations
-    COMPUTE_OP_SHAPE,           # MNK, shape of the operation used in the inner loop
+    compute_warp                # MNK, shape of each warp tile during the inner loop computations
+    compute_op_shape            # MNK, shape of the operation used in the inner loop
 
     #= Layouts =#
-    GLOBAL_A_LAYOUT,            # layout of the A matrix in global memory
-    GLOBAL_B_LAYOUT,            # layout of the B matrix in global memory
-    GLOBAL_C_LAYOUT,            # layout of the C matrix in global memory
-    GLOBAL_D_LAYOUT,            # layout of the D matrix in global memory
+    global_a_layout             # layout of the A matrix in global memory
+    global_b_layout             # layout of the B matrix in global memory
+    global_c_layout             # layout of the C matrix in global memory
+    global_d_layout             # layout of the D matrix in global memory
 
-    SHARED_A_LAYOUT,            # layout of the A matrix in shared memory
-    SHARED_B_LAYOUT,            # layout of the B matrix in shared memory
-    SHARED_C_LAYOUT,            # layout of the C matrix in shared memory
-    SHARED_D_LAYOUT,            # layout of the D matrix in shared memory
+    shared_a_layout             # layout of the A matrix in shared memory
+    shared_b_layout             # layout of the B matrix in shared memory
+    shared_c_layout             # layout of the C matrix in shared memory
+    shared_d_layout             # layout of the D matrix in shared memory
 
     #= Operator =#
-    OPERATOR,                   # which operator to use in the inner loop
+    operator                    # which operator to use in the inner loop
 
     #= Is A & B stored in Column major order? This determines the iteration order of the parallellisation =#
-    IS_A_COL_MAJOR,
-    IS_B_COL_MAJOR
-   }
-end
-
-@inline function Base.getproperty(conf::Type{Config{MATMUL_SHAPE, BLOCK_SHAPE, WARPS_PER_BLOCK, MEM_A_WARP, MEM_A_THREAD, MEM_B_WARP, MEM_B_THREAD, MEM_CD_WARP, MEM_CD_THREAD, COMPUTE_WARP, COMPUTE_OP_SHAPE, GLOBAL_A_LAYOUT, GLOBAL_B_LAYOUT, GLOBAL_C_LAYOUT, GLOBAL_D_LAYOUT, SHARED_A_LAYOUT, SHARED_B_LAYOUT, SHARED_C_LAYOUT, SHARED_D_LAYOUT, OPERATOR, IS_A_COL_MAJOR, IS_B_COL_MAJOR}}, sym::Symbol) where {MATMUL_SHAPE, BLOCK_SHAPE, WARPS_PER_BLOCK, MEM_A_WARP, MEM_A_THREAD, MEM_B_WARP, MEM_B_THREAD, MEM_CD_WARP, MEM_CD_THREAD, COMPUTE_WARP, COMPUTE_OP_SHAPE, GLOBAL_A_LAYOUT, GLOBAL_B_LAYOUT, GLOBAL_C_LAYOUT, GLOBAL_D_LAYOUT, SHARED_A_LAYOUT, SHARED_B_LAYOUT, SHARED_C_LAYOUT, SHARED_D_LAYOUT, OPERATOR, IS_A_COL_MAJOR, IS_B_COL_MAJOR}
-    if sym == :launch_args
-        (; threads = WARPS_PER_BLOCK * 32,
-           blocks = (cld(MATMUL_SHAPE.M, BLOCK_SHAPE.M),
-                     cld(MATMUL_SHAPE.N, BLOCK_SHAPE.N)))
-
-    # convenience accessors for typevars
-    elseif sym == :matmul_shape
-        MATMUL_SHAPE
-    elseif sym == :block_shape
-        BLOCK_SHAPE
-    elseif sym == :warps_per_block
-        WARPS_PER_BLOCK
-    elseif sym == :mem_a_warp
-        MEM_A_WARP
-    elseif sym == :mem_a_thread
-        MEM_A_THREAD
-    elseif sym == :mem_b_warp
-        MEM_B_WARP
-    elseif sym == :mem_b_thread
-        MEM_B_THREAD
-    elseif sym == :mem_cd_warp
-        MEM_CD_WARP
-    elseif sym == :mem_cd_thread
-        MEM_CD_THREAD
-    elseif sym == :compute_warp
-        COMPUTE_WARP
-    elseif sym == :compute_op_shape
-        COMPUTE_OP_SHAPE
-    elseif sym == :global_a_layout
-        GLOBAL_A_LAYOUT
-    elseif sym == :global_b_layout
-        GLOBAL_B_LAYOUT
-    elseif sym == :global_c_layout
-        GLOBAL_C_LAYOUT
-    elseif sym == :global_d_layout
-        GLOBAL_D_LAYOUT
-    elseif sym == :shared_a_layout
-        SHARED_A_LAYOUT
-    elseif sym == :shared_b_layout
-        SHARED_B_LAYOUT
-    elseif sym == :shared_c_layout
-        SHARED_C_LAYOUT
-    elseif sym == :shared_d_layout
-        SHARED_D_LAYOUT
-    elseif sym == :operator
-        OPERATOR
-    elseif sym == :is_a_col_major
-        IS_A_COL_MAJOR
-    elseif sym == :is_b_col_major
-        IS_B_COL_MAJOR
-
-    # fallback
-    else
-        getfield(conf, sym)
-    end
+    is_a_col_major
+    is_b_col_major
 end
 
 function heuristic_block_shape(shared_a_layout, shared_b_layout, shared_c_layout, shared_d_layout)
@@ -199,7 +140,7 @@ function get_config(; gemm_shape, operator, global_a_layout, global_c_layout, kw
     mem_cd_thread = get(params, :mem_cd_thread,
         adjacent_elements(16 ÷ sizeof(Layout.eltype(global_c_layout)), (M = block_shape.M, N = block_shape.N), is_cd_col_major))
 
-    return Config{
+    return Config(
         #= Params =#
         gemm_shape,
         block_shape,
@@ -230,5 +171,5 @@ function get_config(; gemm_shape, operator, global_a_layout, global_c_layout, kw
         #= Is A & B Col Major? =#
         is_a_col_major,
         is_b_col_major,
-    }
+    )
 end

--- a/src/epilogue.jl
+++ b/src/epilogue.jl
@@ -12,7 +12,7 @@ using LLVMLoopInfo: @loopinfo
 
 struct Default end
 
-@inline function (ep::Default)(d, shmem_d, transform, ::Type{conf}) where {conf <: GemmKernels.Config}
+@inline function (ep::Default)(conf::GemmKernels.Config, d, shmem_d, transform)
     # Constants
     block_i = (blockIdx().x - 1) * conf.block_shape.M
     block_j = (blockIdx().y - 1) * conf.block_shape.N
@@ -51,7 +51,7 @@ end
     return ntuple(k -> VecElement{Float32}(x[k].value + b), Val(4))
 end
 
-@inline function (ep::Bias{B})(d, shmem_d, transform, ::Type{conf}) where {B, conf <: GemmKernels.Config}
+@inline function (ep::Bias{B})(conf::GemmKernels.Config, d, shmem_d, transform) where {B}
     # Constants
     block_i = (blockIdx().x - 1) * conf.block_shape.M
     block_j = (blockIdx().y - 1) * conf.block_shape.N

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,79 @@
+"""
+    @staticdef struct Struct
+        foo
+        bar::Typ
+        ...
+    end
+
+Generate a 'static' version of a struct where each field is encoded as a type parameter.
+This is useful when the field values should be specialized on, e.g., in the context of GPU
+kernels.
+
+The macro will generate a struct definition, including a constructor that takes each field
+as an argument (in the same order, and using the same types as the original definition).
+In addition, a `getproperty` accessor is defined such that the fields can be accessed
+using convenient dot syntax (i.e., `obj.field`).
+"""
+macro staticdef(ex)
+    # decode struct definition
+    Meta.isexpr(ex, :struct) || error("@staticdef: expected struct definition")
+    is_mutable, struct_name, struct_body = ex.args
+    is_mutable && error("@staticdef: struct definition must be immutable")
+    ## decode fields
+    @assert Meta.isexpr(struct_body, :block)
+    fields = struct_body.args
+    filter!(field -> !isa(field, LineNumberNode), fields)
+    field_names = Symbol[]
+    field_types = Dict{Symbol, Any}()
+    for field in fields
+        if Meta.isexpr(field, :(::))
+            name, typ = field.args
+        else
+            name = field
+            typ = Any
+        end
+        push!(field_names, name)
+        field_types[name] = typ
+    end
+
+    # generate new struct definition, forwarding args to typevars
+    typevars = Symbol.(uppercase.(String.(field_names)))
+    struct_ex = quote
+        struct $(esc(struct_name)){$(typevars...)}
+            function $(esc(struct_name))($(fields...))
+                new{$(field_names...)}()
+            end
+        end
+    end
+
+    # generate a getproperty accessor
+    getproperties_ex = quote end
+    if !isempty(field_names)
+      current = nothing
+      for field_name in field_names
+          typevar = Symbol(uppercase(String(field_name)))
+          test = :(field === $(QuoteNode(field_name)))
+          if current === nothing
+              current = Expr(:if, test, typevar)
+              getproperties_ex = current
+          else
+              new = Expr(:elseif, test, typevar)
+              push!(current.args, new)
+              current = new
+          end
+      end
+      ## finally, call `getfield` to emit an error
+      push!(current.args, :(getfield(conf, field)))
+      getproperties_ex = quote
+          function Base.getproperty(conf::$(esc(struct_name)){$(typevars...)},
+                                    field::Symbol) where {$(typevars...)}
+            $getproperties_ex
+          end
+      end
+    end
+
+    quote
+        $struct_ex
+        $getproperties_ex
+    end
+end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -53,11 +53,10 @@ using LinearAlgebra
                                             is_b_col_major = !transpose_b,
                                             )
 
-            GemmKernels.matmul(a, b, c, d, conf;
-                                transform_shared_to_regs_a = Transform.Elementwise(x -> x * alpha),
-                                transform_shared_to_regs_c = Transform.Elementwise(x -> x * beta),
-                                kernel = Kernel.matmul_pipelined
-                                )
+            GemmKernels.matmul(conf, a, b, c, d;
+                               transform_shared_to_regs_a = Transform.Elementwise(x -> x * alpha),
+                               transform_shared_to_regs_c = Transform.Elementwise(x -> x * beta),
+                               kernel = Kernel.matmul_pipelined)
 
             # Transpose outputs, if necessary
             new_a_h = transpose_a ? transpose(a_h) : a_h
@@ -111,7 +110,7 @@ using LinearAlgebra
                                             is_b_col_major = !transpose_b,
                                             )
 
-            GemmKernels.matmul(a, b, c, d, conf;
+            GemmKernels.matmul(conf, a, b, c, d;
                                 transform_shared_to_regs_a = Transform.Elementwise(x -> x * alpha),
                                 transform_shared_to_regs_c = Transform.Elementwise(x -> x * beta),
                                 kernel = Kernel.matmul_pipelined
@@ -172,7 +171,7 @@ using LinearAlgebra
                                             is_b_col_major = !transpose_b,
                                             )
 
-            GemmKernels.matmul(a, b, c, d, conf; kernel = Kernel.matmul_pipelined)
+            GemmKernels.matmul(conf, a, b, c, d; kernel = Kernel.matmul_pipelined)
 
             @test d_h ≈ Array(d) rtol=sqrt(eps(A_type))
         end
@@ -212,7 +211,7 @@ using LinearAlgebra
                                           is_b_col_major = !transpose_b,
                                          )
 
-            GemmKernels.matmul(a, b, c, d, conf;
+            GemmKernels.matmul(conf, a, b, c, d;
                                transform_shared_to_regs_a = Transform.Elementwise(x -> x * alpha),
                                transform_shared_to_regs_c = Transform.Elementwise(x -> x * beta),
                                kernel = Kernel.matmul_pipelined
@@ -265,7 +264,7 @@ using LinearAlgebra
                                           is_b_col_major = !transpose_b,
                                          )
 
-            GemmKernels.matmul(a, b, c, d, conf;
+            GemmKernels.matmul(conf, a, b, c, d;
                                epilogue = ep,
                                kernel = Kernel.matmul_pipelined
                               )
@@ -313,7 +312,7 @@ using LinearAlgebra
                                           is_b_col_major = !transpose_b,
                                          )
 
-            GemmKernels.matmul(a, b, c, d, conf)
+            GemmKernels.matmul(conf, a, b, c, d)
 
             # Transpose outputs, if necessary
             new_a_h = transpose_a ? transpose(a_h) : a_h
@@ -373,7 +372,7 @@ using LinearAlgebra
                                           is_b_col_major = !transpose_b
                                          )
 
-            GemmKernels.matmul(a, b, c, d, conf;
+            GemmKernels.matmul(conf, a, b, c, d;
                                kernel = Kernel.matmul_pipelined)
 
             new_a_h = a_h
@@ -428,7 +427,7 @@ using LinearAlgebra
                                           mem_cd_thread = (M = 2, N = 1)
                                          )
 
-            GemmKernels.matmul(a, b, c, d, conf;
+            GemmKernels.matmul(conf, a, b, c, d;
                                kernel = Kernel.matmul_pipelined)
 
             a_dual = reinterpret(ForwardDiff.Dual{Float32,Float32,1}, Complex{Float32}.(a_h))


### PR DESCRIPTION
Use some metaprogramming to generate the struct, and pass it around as a singleton value instead of its type. Also move it to the first arg in kernel and function calls, which seems more idiomatic to me.