### PR TITLE
Add a mechanism to expose execution details to callers.

### DIFF
--- a/benchmarks/Project.toml
+++ b/benchmarks/Project.toml
@@ -2,4 +2,5 @@
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Git = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
 GitHub = "bc5e4493-9b4d-5f90-b8aa-2b2bcaad7a26"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"

--- a/benchmarks/blas.jl
+++ b/benchmarks/blas.jl
@@ -1,5 +1,13 @@
 group = addgroup!(SUITE, "BLAS")
 
+short_type(T::Type) = string(T)
+short_type(::Type{Float16}) = "FP16"
+short_type(::Type{Float32}) = "FP32"
+short_type(::Type{Float64}) = "FP64"
+short_type(::Type{ComplexF16}) = "cFP16"
+short_type(::Type{ComplexF32}) = "cFP32"
+short_type(::Type{ComplexF64}) = "cFP64"
+
 function blas_benchmark(group, a_type, b_type, cd_type, N, M=N, K=N; alpha=true, beta=false,
                         a_transpose=false, b_transpose=false, kwargs...)
     a_h = rand(a_type, (M, K))
@@ -14,14 +22,14 @@ function blas_benchmark(group, a_type, b_type, cd_type, N, M=N, K=N; alpha=true,
 
     # generate a name for the benchmark
     io = IOBuffer()
-    print(io, a_type)
+    print(io, short_type(a_type))
     a_transpose && print(io, "'")
     print(io, "*")
-    print(io, b_type)
+    print(io, short_type(b_type))
     b_transpose && print(io, "'")
-    print(io, "=$cd_type ($N×$K×$N")
-    alpha && print(io, ", alpha")
-    beta && print(io, ", beta")
+    print(io, "=$(short_type(cd_type)) ($N×$K×$N")
+    alpha && print(io, ", α")
+    beta && print(io, ", β")
     print(io, ")")
     name = String(take!(io))
 

--- a/benchmarks/blas.jl
+++ b/benchmarks/blas.jl
@@ -25,6 +25,16 @@ function blas_benchmark(group, a_type, b_type, cd_type, N, M=N, K=N; alpha=true,
     print(io, ")")
     name = String(take!(io))
 
+    # abuse the BenchmarkGroup hierarchy to store some information about the execution
+    a = CuArray(a_h)
+    b = CuArray(b_h)
+    c = CuArray(c_h)
+    info = GemmKernels.Information()
+    GemmKernels.matmatmul!(c, a_layout, b_layout, a, b, alpha, beta; info, kwargs...)
+    group[name * " details"] =
+        (; info.registers,
+           info.dynamic_shared_mem, info.static_shared_mem, info.local_mem, info.const_mem)
+
     # NOTE: we use `cuStreamSynchronize` instead of `synchronize` to avoid
     #       influence from the Julia scheduler
     group[name] = @benchmarkable(

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -95,17 +95,7 @@ function markdown_escaped_code(str)
     ticks = "`"^ticks
     return string(ticks, startswith(str, '`') ? " " : "", str, endswith(str, '`') ? " " : "", ticks)
 end
-idrepr(id::Vector) = sprint(idrepr, id)
-function idrepr(io::IO, id::Vector)
-    print(io, "[")
-    first = true
-    for i in id
-        first ? (first = false) : print(io, ", ")
-        show(io, i)
-    end
-    print(io, "]")
-end
-idrepr_md(id::Vector) = markdown_escaped_code(idrepr(id))
+idrepr(ids::Vector) = join(map(markdown_escaped_code, ids), ": ")
 function resultrow(ids, j::BenchmarkTools.TrialJudgement,
                    old::BenchmarkTools.Trial, new::BenchmarkTools.Trial)
     t_old = @sprintf("%s ± %s", BenchmarkTools.prettytime(time(mean(old))),
@@ -114,7 +104,7 @@ function resultrow(ids, j::BenchmarkTools.TrialJudgement,
                                 BenchmarkTools.prettytime(time(std(new))))
     ratio = @sprintf("%.1f%%", 100*(1-BenchmarkTools.time(BenchmarkTools.ratio(j))))
     mark = resultmark(BenchmarkTools.time(j))
-    return "| $(idrepr_md(ids)) | $(t_old) | $(t_new) | $(ratio) $(mark) |"
+    return "| $(idrepr(ids)) | $(t_old) | $(t_new) | $(ratio) $(mark) |"
 end
 const REGRESS_MARK = ":x:"
 const IMPROVE_MARK = ":white_check_mark:"

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -68,6 +68,9 @@ end
 details = Dict(extract_details(SUITE))
 display(details)
 
+@info "Warming-up benchmarks"
+warmup(SUITE; verbose=false)
+
 @info "Running benchmarks"
 timings = run(SUITE; verbose=true)
 println(timings)


### PR DESCRIPTION
Use it to save those as part of the benchmark results.