### PR TITLE
Adapt to CUDA.jl profile changes

### DIFF
--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -115,7 +115,7 @@ for cf in get_configs()
     run_gemm(cf, a, b, c, d)
 
     # benchmark
-    profile_results = CUDA.@profiled begin
+    profile_results = CUDA.@profile begin
         for sample in 1:NUM_SAMPLES
             run_gemm(cf, a, b, c, d)
         end


### PR DESCRIPTION
ref https://github.com/JuliaGPU/CUDA.jl/pull/2139

Probably should add methods to CUDA.jl to access the kernel times instead of grabbing them directly from the dataframe.