### PR TITLE
Apply isapprox elementwise

### DIFF
--- a/configs/configs.jl
+++ b/configs/configs.jl
@@ -91,21 +91,23 @@ end
 
 # Verify results.
 function verify(cf::Configuration, c_ref, d)
-    cf.verify(c_ref, d)
+    cf.verify(c_ref, d, cf.a_type)
 end
 
-function verify_default(c_ref, d)
-    all(isapprox.(c_ref, d))
+compare(x, y, T) = isapprox(x, y; rtol=sqrt(eps(T)))
+
+function verify_default(c_ref, d, T)
+    all(compare.(c_ref, d, T))
 end
 
-function verify_bias(c_ref, d, bias)
-    all(isapprox.(c_ref .+ bias, d))
+function verify_bias(c_ref, d, bias, T)
+    all(compare.(c_ref .+ bias, d, T))
 end
 
-function verify_dual(c_ref, d)
+function verify_dual(c_ref, d, T)
     c_dual = reinterpret(ForwardDiff.Dual{Float32,Float32,1}, c_ref)
     d_dual = reinterpret(ForwardDiff.Dual{Float32,Float32,1}, d)
-    all(isapprox.(c_dual, d_dual))
+    all(compare.(c_dual, d_dual, T))
 end
 
 function fpu_baseline(a, b, c, d, alpha, beta, transpose_a, transpose_b)

--- a/configs/configs.jl
+++ b/configs/configs.jl
@@ -94,7 +94,10 @@ function verify(cf::Configuration, c_ref, d)
     cf.verify(c_ref, d, cf.a_type)
 end
 
-compare(x, y, T) = isapprox(x, y; rtol=sqrt(eps(T)))
+compare(x, y, T) = error("Unimplemented compare(x, y, T) function for type $T")
+compare(x, y, T::Type{<:AbstractFloat}) = isapprox(x, y; rtol=sqrt(eps(T)))
+compare(x, y, T::Type{<:Integer}) = (x == y)
+compare(x, y, T::Type{Complex{U}}) where {U} = compare(x, y, U)
 
 function verify_default(c_ref, d, T)
     all(compare.(c_ref, d, T))
@@ -284,7 +287,7 @@ macro get_wmma_bias_config()
                       transpose_b,
                       mul!,
                       Epilogue.Bias(pointer(bias)),
-                      (c_h, d) -> verify_bias(c_h, d, bias),
+                      (c_h, d, T) -> verify_bias(c_h, d, bias, T),
                       Kernel.matmul_pipelined,
                       nothing)
     end end)

--- a/configs/configs.jl
+++ b/configs/configs.jl
@@ -95,17 +95,17 @@ function verify(cf::Configuration, c_ref, d)
 end
 
 function verify_default(c_ref, d)
-    isapprox(c_ref, d)
+    all(isapprox.(c_ref, d))
 end
 
 function verify_bias(c_ref, d, bias)
-    c_ref .+ bias ≈ d
+    all(isapprox.(c_ref .+ bias, d))
 end
 
 function verify_dual(c_ref, d)
     c_dual = reinterpret(ForwardDiff.Dual{Float32,Float32,1}, c_ref)
     d_dual = reinterpret(ForwardDiff.Dual{Float32,Float32,1}, d)
-    isapprox(c_dual, d_dual)
+    all(isapprox.(c_dual, d_dual))
 end
 
 function fpu_baseline(a, b, c, d, alpha, beta, transpose_a, transpose_b)


### PR DESCRIPTION
Applying `isapprox` elementwise rather than on the entire matrix catches incorrect output better, since by default, `isapprox` on matrices uses the Frobenius ($L_2$) norm, $$||M|| = \sqrt{\sum_{i=1}^N \sum_{j=1}^N |a_{ij} |^2}$$, which scales with the matrix size, so larger matrices tolerate larger errors with a relative tolerance:

```
julia> A = rand(Float32, (4, 4));

julia> B = copy(A);

julia> isapprox(A, B)
true

julia> B[1] *= 1.01;

julia> isapprox(A, B)
false

julia> A = rand(Float32, (2048, 2048));

julia> B = copy(A);

julia> isapprox(A, B)
true

julia> B[1] *= 1.01;

julia> isapprox(A, B)
true
```

We could use absolute tolerance, or switch to the $L_\infty$-norm instead $$||M|| = \max_{i,j} |a_{ij}|$$

by passing a custom `norm` function to `isapprox`, which does handle inaccuracies better:
```
julia> using LinearAlgebra

julia> A = rand(Float32, (2048, 2048));

julia> B = copy(A);

julia> isapprox(A, B)
true

julia> isapprox(A, B; norm=M->LinearAlgebra.norm(M, Inf))
true

julia> B[1] *= 1.01;

julia> isapprox(A, B)
true

julia> isapprox(A, B; norm=M->LinearAlgebra.norm(M, Inf))
false
```

But let's just go for the easiest approach and apply `isapprox` elementwise instead.