### PR TITLE
Remove Julia 1.8 from CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,7 +28,6 @@ steps:
         matrix:
           setup:
             julia:
-              - "1.8"
               - "1.9"
               - "1.10"
           #     - "nightly"


### PR DESCRIPTION
1.8 is one year old already, and CI times out anyway.