### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,8 +9,7 @@ steps:
           - JuliaCI/julia-test#v1: ~
           - JuliaCI/julia-coverage#v1: ~
         agents:
-          queue: "juliagpu"
-          cuda: "*"
+          queue: "cuda"
         commands: |
           julia --project -e '
               # make sure the 1.6-era Manifest works on this Julia version
@@ -55,8 +54,8 @@ steps:
   #           println("+++ :julia: Benchmarking")
   #           include("benchmarks/runbenchmarks.jl")'
   #       agents:
-  #         queue: "benchmark"
-  #         cuda: "*"
+  #         queue: "cuda"
+  #         benchmark: "*"
   #         gpu: "rtx4070"
   #       if: build.message !~ /\[skip benchmarks\]/
   #       matrix:


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"` instead of `queue: "juliagpu"` combined with a `cuda` tag.

The commented-out benchmark steps were updated as well: the separate `benchmark` queue is gone, and benchmark agents now live in the `cuda` queue with a `benchmark: "*"` tag.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)